### PR TITLE
Split documentation in multiple files

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -1,3 +1,5 @@
 #lang racket/base
-(require "nonlinear.rkt")
-(provide (all-from-out "nonlinear.rkt"))
+(require "nonlinear.rkt"
+         "approximation.rkt")
+(provide (all-from-out "nonlinear.rkt")
+         (all-from-out "approximation.rkt"))

--- a/nonlinear.rkt
+++ b/nonlinear.rkt
@@ -1,5 +1,5 @@
 #lang racket
-(provide (prefix-out octavian/ (all-defined-out)))
+(provide (all-defined-out))
 
 ;; BISECTION find a zero of function `f` in interval `[a, b]`, with a tolerance
 ;;   `𝛆` in the result.  Optionally, pass a maximum number of iterations

--- a/scribblings/approximation.scrbl
+++ b/scribblings/approximation.scrbl
@@ -1,0 +1,24 @@
+#lang scribble/manual
+@(require scribble/examples)
+@(require "pr-math.rkt")
+@require[@for-label[octavian
+                    racket]]
+
+@setup-math
+@(define octavian-eval (make-base-eval))
+@(octavian-eval '(require octavian))
+
+@title{Approximation of functions and data}
+
+
+@defproc[(polyfit [xs (listof real?)] [ys (listof real?)] [grade real?])
+         (col-matrix?)]
+fits a function @${f(x)}, described by a list of coordinates @racket[xs] and a
+list of values @racket[ys], with a polynomial of up to a specified
+@racket[grade].  The polynomial @${\tilde{f}} is a good fit for the function in
+the sense that it minimizes the sum of squared errors between the approximated
+function values and the actual values @${y} at the given coordinates, when
+compared with any other approximation using polynomials.
+
+@$${\forall p_m \in \mathbb{P}_m:
+\sum_{i=0}^{n}{[y_i - \tilde{f}(x_i)]^2} \leq \sum_{i=0}^{n}{[y_i - p_m(x_i)]^2}}

--- a/scribblings/nonlinear.scrbl
+++ b/scribblings/nonlinear.scrbl
@@ -1,0 +1,66 @@
+#lang scribble/manual
+@(require scribble/examples)
+@(require "pr-math.rkt")
+@require[@for-label[octavian
+                    racket]]
+
+@setup-math
+@(define octavian-eval (make-base-eval))
+@(octavian-eval '(require octavian))
+
+@title{Non-linear equations}
+
+@defmodule[octavian/nonlinear]
+
+Procedures defined for non-linear equations are algorithms that find
+@italic{zeroes} or @italic{fixed points} of a function. Functions are expected
+to be real, i.e. they map real variables to real values. Zeroes of a function
+are those values @${x} where: @${f(x) = 0}. Fixed points of a
+function are values @${x} where: @${f(x) = x}.
+
+@defproc[(bisection [f (-> real? real?)] [a real?] [b real?] [𝛆 real?]
+          [nmax (k_min a b 𝛆)])
+         (real-in a b)]
+finds a zero of function @${f} in interval @${[a, b]}, with tolerance
+@${𝛆} in the result.  Optionally, pass a maximum number of iterations
+@italic{nmax}.  There is a procedure, @racket[k_min], to obtain a number of steps
+@italic{k_min} that are enough to reach the zero; by default, this formula is
+used if no @italic{nmax} is supplied.
+
+@examples[#:eval octavian-eval
+(let ([𝛆 1e-5]
+      [f (lambda (x) x)])
+    (bisection f 0 1 𝛆))
+]
+
+
+@defproc[(k_min [a real?] [b real?] [𝛆 real?])
+          (integer?)]
+computes the minimum number of steps that are necessary to find a zero in the
+interval @${[a, b]} with tolerance @${𝛆} by the procedure @racket[bisection].
+
+
+@defproc[(newton [f (-> real? real?)] [df (-> real? real?)] [x_0 real?] [𝛆 real?]
+          [nmax integer?])
+         (real?)]
+fnd zeroes of function @${f} using Newton's method, which requires the
+derivative function @${df} and a starting point @${x_0}.  The
+function also takes a tolerance @${𝛆} and a maximum number of iterations
+@italic{nmax}.
+
+
+@defproc[(aitken [𝜙 (-> real? real?)] [x real?] [𝛆 real?] [nmax integer?]
+          [niter integer?] [diff real?])
+         (real?)]
+finds approximations of fixed point @${𝜶} of function @${𝜙} starting
+from initial point @${x_0} using Aitken's extrapolation method. The method
+stops after a given @italic{nmax} iterations (default: 100), or after the
+absolute value of the difference between two consecutive iterations is less
+than a given tolerance @${𝛆} (default: 1 * 10e-4).
+
+
+@defproc[(hoerner [a (listof integer?)] [z real?])
+         (real?)]
+evaluates efficiently polynomial @italic{a} at point @italic{z}. The polynomial
+is expected to be a list of coefficients @${(a_0 ... a_n)}, ordered from lowest
+to highest degree.

--- a/scribblings/octavian.scrbl
+++ b/scribblings/octavian.scrbl
@@ -6,7 +6,7 @@
 
 @setup-math
 @(define octavian-eval (make-base-eval))
-@(octavian-eval '(require octavian/nonlinear))
+@(octavian-eval '(require octavian))
 
 @title{octavian: scientific computing methods}
 @author{Luis Osa}
@@ -18,71 +18,5 @@ found in Octave & MATLAB.
 
 @table-of-contents[]
 
-@section{Non-linear equations}
-
-@defmodule[nonlinear]
-
-Procedures defined for non-linear equations are algorithms that find
-@italic{zeroes} or @italic{fixed points} of a function. Functions are expected
-to be real, i.e. they map real variables to real values. Zeroes of a function
-are those values @${x} where: @${f(x) = 0}. Fixed points of a
-function are values @${x} where: @${f(x) = x}.
-
-@defproc[(octavian/bisection [f (-> real? real?)] [a real?] [b real?] [𝛆 real?]
-          [nmax (k_min a b 𝛆)])
-         (real-in a b)]
-finds a zero of function @${f} in interval @${[a, b]}, with tolerance
-@${𝛆} in the result.  Optionally, pass a maximum number of iterations
-@italic{nmax}.  There is a procedure, @racket[k_min], to obtain a number of steps
-@italic{k_min} that are enough to reach the zero; by default, this formula is
-used if no @italic{nmax} is supplied.
-
-@examples[#:eval octavian-eval
-(let ([𝛆 1e-5]
-      [f (lambda (x) x)])
-    (octavian/bisection f  0 1 𝛆))
-]
-
-@defproc[(k_min [a real?] [b real?] [𝛆 real?])
-          (integer?)]
-computes the minimum number of steps that are necessary to find a zero in the
-interval @${[a, b]} with tolerance @${𝛆} by the procedure @racket[bisection].
-
-@defproc[(newton [f (-> real? real?)] [df (-> real? real?)] [x_0 real?] [𝛆 real?]
-          [nmax integer?])
-         (real?)]
-fnd zeroes of function @${f} using Newton's method, which requires the
-derivative function @${df} and a starting point @${x_0}.  The
-function also takes a tolerance @${𝛆} and a maximum number of iterations
-@italic{nmax}.
-
-@defproc[(aitken [𝜙 (-> real? real?)] [x real?] [𝛆 real?] [nmax integer?]
-          [niter integer?] [diff real?])
-         (real?)]
-finds approximations of fixed point @${𝜶} of function @${𝜙} starting
-from initial point @${x_0} using Aitken's extrapolation method. The method
-stops after a given @italic{nmax} iterations (default: 100), or after the
-absolute value of the difference between two consecutive iterations is less
-than a given tolerance @${𝛆} (default: 1 * 10e-4).
-
-@defproc[(hoerner [a (listof integer?)] [z real?])
-         (real?)]
-evaluates efficiently polynomial @italic{a} at point @italic{z}. The polynomial
-is expected to be a list of coefficients @${(a_0 ... a_n)}, ordered from lowest
-to highest degree.
-
-@section{Approximation of functions and data}
-
-@defproc[(polyfit [xs (listof real?)] [ys (listof real?)] [grade real?])
-         (col-matrix?)]
-fits a function @${f(x)}, described by a list of coordinates @racket[xs] and a
-list of values @racket[ys], with a polynomial of up to a specified
-@racket[grade].  The polynomial @${\tilde{f}} is a good fit for the function in
-the sense that it minimizes the sum of squared errors between the approximated
-function values and the actual values @${y} at the given coordinates, when
-compared with any other approximation using polynomials.
-
-@$${\forall p_m \in \mathbb{P}_m:
-\sum_{i=0}^{n}{[y_i - \tilde{f}(x_i)]^2} \leq \sum_{i=0}^{n}{[y_i - p_m(x_i)]^2}}
-
-
+@include-section["nonlinear.scrbl"]
+@include-section["approximation.scrbl"]

--- a/scribblings/pr-math.rkt
+++ b/scribblings/pr-math.rkt
@@ -14,8 +14,8 @@
   )
 
 (define setup-math
-  (paragraph 
-   (style 
+  (paragraph
+   (style
     #f (list (alt-tag "script")
              (attributes `((type . "text/javascript")
                            (src . ,mathjax-source )))))
@@ -24,7 +24,7 @@
 (define (mymath start end . strs)
   (make-element (make-style "relax" '(exact-chars)) `(,start ,@strs ,end)))
 
-(define (math-in . strs) 
+(define (math-in . strs)
   (apply mymath "\\(" "\\)" strs))
 
 (define (math-disp . strs)

--- a/test_nonlinear.rkt
+++ b/test_nonlinear.rkt
@@ -7,17 +7,17 @@
   (let ([𝛆 1e-5]
         [f (lambda (x) x)]
         [g (lambda (x) (+ x 1))])
-    (check-= (octavian/bisection f  0 1 𝛆) 0 𝛆)
-    (check-= (octavian/bisection f -1 0 𝛆) 0 𝛆)
-    (check-= (octavian/bisection f -1 1 𝛆) 0 𝛆)
-    (check-= (octavian/bisection g -1 1 𝛆) -1 𝛆)
-    (check-= (octavian/bisection g -2 2 𝛆) -1 𝛆)))
+    (check-= (bisection f  0 1 𝛆) 0 𝛆)
+    (check-= (bisection f -1 0 𝛆) 0 𝛆)
+    (check-= (bisection f -1 1 𝛆) 0 𝛆)
+    (check-= (bisection g -1 1 𝛆) -1 𝛆)
+    (check-= (bisection g -2 2 𝛆) -1 𝛆)))
 (test-case
   "Bisection with max-iter less than correct"
   (let ([𝛆 1e-5]
         [h (lambda (x) (- (sqr x) 1))])
-    (check-= (octavian/bisection h -0.25 1.25 𝛆 3) 0.96875 𝛆)
-    (check-= (octavian/bisection h -0.25 1.25 𝛆 (octavian/k_min -0.25 1.25 𝛆)) 1 𝛆)))
+    (check-= (bisection h -0.25 1.25 𝛆 3) 0.96875 𝛆)
+    (check-= (bisection h -0.25 1.25 𝛆 (k_min -0.25 1.25 𝛆)) 1 𝛆)))
 
 (test-case
   "Investment fund"
@@ -27,7 +27,7 @@
                                (M . - . (* v ((1 . + . r) . / . r)
                                            ((expt (1 . + .  r) 5) . - . 1))))]
                            [f (curry avg-return-rate 1000 6000)])
-    (check-= (octavian/bisection f a b 𝛆) 0.06140241153618 𝛆)))
+    (check-= (bisection f a b 𝛆) 0.06140241153618 𝛆)))
 
 (test-case
   "Basic Newton tests"
@@ -38,12 +38,12 @@
         [dg (lambda (x) 1)]
         [h (lambda (x) (- (sqr x) 1))]
         [dh (lambda (x) (* 2 x))])
-    (check-= (octavian/newton f df -1 𝛆 1) 0 𝛆)
-    (check-= (octavian/newton f df -10 𝛆 1) 0 𝛆)
-    (check-= (octavian/newton g dg 0 𝛆 1) -1 𝛆)
-    (check-= (octavian/newton g dg 0.22 𝛆 1) -1 𝛆)
-    (check-= (octavian/newton h dh 2 𝛆 10) 1 𝛆)
-    (check-= (octavian/newton h dh -10 𝛆 10) -1 𝛆)))
+    (check-= (newton f df -1 𝛆 1) 0 𝛆)
+    (check-= (newton f df -10 𝛆 1) 0 𝛆)
+    (check-= (newton g dg 0 𝛆 1) -1 𝛆)
+    (check-= (newton g dg 0.22 𝛆 1) -1 𝛆)
+    (check-= (newton h dh 2 𝛆 10) 1 𝛆)
+    (check-= (newton h dh -10 𝛆 10) -1 𝛆)))
 
 (test-case
   "Investment fund solved by Newton"
@@ -57,7 +57,7 @@
                                 (* v (+ r 1) (((expt (+ r 1) 5) . - . 1) . / .  (sqr r)))))]
          [f (curry avg-return-rate 1000 6000)]
          [df (curry davg-return-rate 1000)])
-    (check-= (octavian/newton f df 0.01 𝛆 3) 0.06140241153618 𝛆)))
+    (check-= (newton f df 0.01 𝛆 3) 0.06140241153618 𝛆)))
 
 (test-case
   "Find root 𝜶 = 1 of function `f(x) = e^x * (x - 1)` using Aitken's method"
@@ -65,13 +65,13 @@
         [𝜙_1 (lambda (x) (/ (+ (exp x) x) (+ (exp x) 1)))]
         [𝛆 1e-10]
         [x_0 2])
-    (check-= (octavian/aitken 𝜙_0 x_0 𝛆) 1.0 𝛆)
-    (check-= (octavian/aitken 𝜙_1 x_0 𝛆) 1.0 𝛆)))
+    (check-= (aitken 𝜙_0 x_0 𝛆) 1.0 𝛆)
+    (check-= (aitken 𝜙_1 x_0 𝛆) 1.0 𝛆)))
 
 (test-case
   "Check that Hörner synthetic division does the same as a normal evaluation"
-  (check-eqv? (octavian/hoerner '(1 1 1) 2) (+ 1 (* 1 2) (* 1 (sqr 2))))
-  (check-eqv? (octavian/hoerner '(0 2 3 1) 3) (+ 0 (* 2 3) (* 3 (sqr 3)) (expt 3 3)))
-  (check-eqv? (octavian/hoerner '(1 1 1) 0) 1)
-  (check-eqv? (octavian/hoerner '(7 0 1) 1) (+ 7 (sqr 1))))
+  (check-eqv? (hoerner '(1 1 1) 2) (+ 1 (* 1 2) (* 1 (sqr 2))))
+  (check-eqv? (hoerner '(0 2 3 1) 3) (+ 0 (* 2 3) (* 3 (sqr 3)) (expt 3 3)))
+  (check-eqv? (hoerner '(1 1 1) 0) 1)
+  (check-eqv? (hoerner '(7 0 1) 1) (+ 7 (sqr 1))))
 


### PR DESCRIPTION
Split documentation file in several sections, included each into the main document via `include-section`.

Also, simplify the `provide` mechanism of functions. Clients are now expected to rename the `required` functions, if they do not want conflicts with their own definitions.