### PR TITLE
Trigonometric interpolation and fft

### DIFF
--- a/approximation.rkt
+++ b/approximation.rkt
@@ -4,7 +4,8 @@
 (provide polyfit
          polyval
          chebyshev-nodes
-         barycentric)
+         barycentric
+         dft)
 
 ;; POLYFIT returns the Lagrange interpolation polynomial of grade `n` that fits
 ;;   values `ys` at points `xs` with least squared error.
@@ -64,3 +65,16 @@
     (for/sum ([k (in-range 0 n)] [x_k xs])
       ((barycentric-weights k) . / . (x_1 . - . x_k))))
   (barycentric-numerator . / . barycentric-denominator))
+
+;; DFT discrete Fourier transform
+(define (dft X)
+  (define N (array-size X))
+  (define (naive-dft X)
+    (for/array ([k (in-range N)])
+               (for/sum ([n (in-range N)])
+                 (* (array-ref X (vector n))
+                    (exp (* (/ (* -2 pi 0+i) N) n k))))))
+  (cond [(N . < . 100) (naive-dft X)]
+        ;; placeholder for other implementations
+        [else (naive-dft X)])
+  )

--- a/approximation.rkt
+++ b/approximation.rkt
@@ -91,15 +91,16 @@
 (define (idft X)
   (define N (array-size X))
   (define (naive-idft X)
-    (array-map (λ (x) (* (1 . / . N) x))
-               (for/array ([k (in-range N)])
-                          (for/sum ([l (in-range N)])
-                            (* (array-ref X (vector l))
-                               (inverse-twiddle-factor N l k))))))
-  (cond [(N . < . 100) (naive-idft X)]
-        [(power-of-two? N) (array-inverse-fft X)]
-        [(not  (prime? N)) (cooley-turkey-idft X)]
-        [else              (rader-idft X)]))
+    (for/array ([k (in-range N)])
+               (for/sum ([l (in-range N)])
+                 (* (array-ref X (vector l))
+                    (inverse-twiddle-factor N l k)))))
+  (define (scale result)
+    (array-map (λ (x) (* (1 . / . N) x)) result))
+  (scale (cond [(N . < . 100) (naive-idft X)]
+               [(power-of-two? N) (array-inverse-fft X)]
+               [(not  (prime? N)) (cooley-turkey-idft X)]
+               [else              (rader-idft X)])))
 
 ;; COOLEY-TURKEY-DFT is a fast Fourier transform for arrays of non-prime length
 ;;   cf. http://cnx.org/contents/ulXtQbN7@15/Implementing-FFTs-in-Practice#uid37

--- a/approximation.rkt
+++ b/approximation.rkt
@@ -7,8 +7,7 @@
          dft
          idft
          cooley-turkey-dft
-         rader-dft
-         fft-factorize)
+         rader-dft)
 
 (require math/base
          math/number-theory
@@ -98,7 +97,6 @@
                             (* (array-ref X (vector l))
                                (inverse-twiddle-factor N l k))))))
   (cond [(N . < . 100) (naive-idft X)]
-        ;; TODO: hook up other implementations
         [(power-of-two? N) (array-inverse-fft X)]
         [(not  (prime? N)) (cooley-turkey-idft X)]
         [else              (rader-idft X)]))

--- a/approximation.rkt
+++ b/approximation.rkt
@@ -1,11 +1,19 @@
 #lang racket
-(require math/matrix
-         math/array)
+
 (provide polyfit
          polyval
          chebyshev-nodes
          barycentric
-         dft)
+         dft
+         idft
+         cooley-turkey-dft
+         rader-dft
+         fft-factorize)
+
+(require math/base
+         math/number-theory
+         math/matrix
+         math/array)
 
 ;; POLYFIT returns the Lagrange interpolation polynomial of grade `n` that fits
 ;;   values `ys` at points `xs` with least squared error.
@@ -66,15 +74,114 @@
       ((barycentric-weights k) . / . (x_1 . - . x_k))))
   (barycentric-numerator . / . barycentric-denominator))
 
-;; DFT discrete Fourier transform
+;; DFT discrete Fourier transform, not restricted to arrays with a length that
+;;   is a power of 2.
 (define (dft X)
   (define N (array-size X))
   (define (naive-dft X)
     (for/array ([k (in-range N)])
-               (for/sum ([n (in-range N)])
-                 (* (array-ref X (vector n))
-                    (exp (* (/ (* -2 pi 0+i) N) n k))))))
+               (for/sum ([l (in-range N)])
+                 (* (array-ref X (vector l))
+                    (twiddle-factor N l k)))))
   (cond [(N . < . 100) (naive-dft X)]
-        ;; placeholder for other implementations
-        [else (naive-dft X)])
-  )
+        [(power-of-two? N) (array-fft X)]
+        [(not  (prime? N)) (cooley-turkey-dft X)]
+        [else              (rader-dft X)]))
+
+;; IDFT inverse discrete Fourier transform
+(define (idft X)
+  (define N (array-size X))
+  (define (naive-idft X)
+    (array-map (λ (x) (* (1 . / . N) x))
+               (for/array ([k (in-range N)])
+                          (for/sum ([l (in-range N)])
+                            (* (array-ref X (vector l))
+                               (inverse-twiddle-factor N l k))))))
+  (cond [(N . < . 100) (naive-idft X)]
+        ;; TODO: hook up other implementations
+        [(power-of-two? N) (array-inverse-fft X)]
+        [(not  (prime? N)) (cooley-turkey-idft X)]
+        [else              (rader-idft X)]))
+
+;; COOLEY-TURKEY-DFT is a fast Fourier transform for arrays of non-prime length
+;;   cf. http://cnx.org/contents/ulXtQbN7@15/Implementing-FFTs-in-Practice#uid37
+(define (cooley-turkey-dft X)
+  (cooley-turkey-algorithm X twiddle-factor))
+
+(define (cooley-turkey-idft X)
+  (cooley-turkey-algorithm X inverse-twiddle-factor))
+
+(define (cooley-turkey-algorithm X twiddle-function)
+  (define n (array-size X))
+  (define-values (n1 n2) (fft-factorize n))
+  (for*/array
+   ([k2 (in-range n2)]
+    [k1 (in-range n1)])
+   (for/sum ([l2 (in-range n2)])
+     (* (* (for/sum ([l1 (in-range n1)])
+             (* (array-ref X (vector (+ (* l1 n2) l2)))
+                (twiddle-function n1 l1 k1)))
+           (twiddle-function n l2 k1))
+        (twiddle-function n2 l2 k2)))))
+
+;; TWIDDLE-FACTOR is a primitive root of unity. In the literature it is often
+;;   represented as `w_n^{lk}`
+(define (twiddle-factor n l k)
+  (ω -1 n l k))
+
+(define (inverse-twiddle-factor n l k)
+  (ω +1 n l k))
+
+(define (ω sign n l k)
+  (exp (/ (* sign 2 pi 0+i l k) n)))
+
+;; FFT-FACTORIZE returns a small divisor and a big divisor of N. The first one
+;;   can be the radix and the second one can be the outer factor for a
+;;   Cooley-Turkey FFT algorithm
+(define (fft-factorize n)
+  (let ([divisor-list (non-trivial-divisors n)])
+    (values (first divisor-list) (last divisor-list))))
+
+;; NON-TRIVIAL-DIVISORS returns a list of divisors, excluding the first one, 1,
+;;   and the last one, n
+(define (non-trivial-divisors n)
+  (reverse (cdr (reverse (cdr (divisors n))))))
+
+;; RADER-DFT is a fast Fourier transform for arrays of prime size
+;; cf. https://skybluetrades.net/blog/posts/2013/12/31/data-analysis-fft-9.html
+;; cf. https://en.wikipedia.org/wiki/Rader%27s_FFT_algorithm
+(define (rader-dft X)
+  (rader-algorithm X -1))
+
+(define (rader-idft X)
+  (rader-algorithm X 1))
+
+(define (rader-algorithm X twiddle-factor-sign)
+  (define p (array-size X))
+  (define g (primitive-root p))
+  ;; index-scheme is a reordering of elements given by g^p in the multiplicative
+  ;; group Z_p: https://en.wikipedia.org/wiki/Multiplicative_group_of_integers_modulo_n
+  (define index-scheme
+    (map (λ (x) (with-modulus p (modexpt g x))) (range (- p 1))))
+  (define omega-index-scheme
+    (map (λ (x) (with-modulus p (mod/ 1 (modexpt g x)))) (range (- p 1))))
+  (define indexes
+    (for/array ([idx index-scheme]) (vector idx)))
+  (define omega-indexes
+    (for/array ([idx omega-index-scheme]) (vector idx)))
+  (define inverse-idxs
+    (for/list ([k (in-range 1 (add1 (length omega-index-scheme)))]
+               [idx omega-index-scheme])
+      (cons idx k)))
+  (define (find-old-idx new-idx) (cdr (assoc new-idx inverse-idxs)))
+  (define (invert-reorder reordered)
+    (for/array ([k (in-range 1 (add1 (array-size reordered)))])
+               (array-ref reordered (vector (sub1 (find-old-idx k))))))
+  (define h_tilde (array-indexes-ref X indexes))
+  (define (w x) (ω twiddle-factor-sign p x 1))
+  (define omega (list->array (map (lambda (x) (w x)) (range p))))
+  (define w_tilde (array-indexes-ref omega omega-indexes))
+  (define h_0 (for/sum ([x (in-array X)]) x))
+  (define H_tilde (idft (array* (dft h_tilde) (dft w_tilde))))
+  (define H (invert-reorder H_tilde))
+  (list->array (cons h_0 (array->list H))))

--- a/scribblings/approximation.scrbl
+++ b/scribblings/approximation.scrbl
@@ -2,7 +2,8 @@
 @(require scribble/examples)
 @(require "pr-math.rkt")
 @require[@for-label[octavian
-                    racket]]
+                    racket
+                    math/array]]
 
 @setup-math
 @(define octavian-eval (make-base-eval))
@@ -61,4 +62,46 @@ computes the value at the abscissae @${x_1} of the polynomial interpolating data
 where
 
 @$${w_k = \left(\prod_{\substack{j=0 \\ j \neq k}}^{n}{x_k - x_j}\right)^{-1} , k=0,...,n}
+}
+
+
+@defproc[
+(dft [X (Array A)])
+(Array A)
+]{
+returns the discrete Fourier transform of the array @${X}. Unlike @racket[array-fft], it is
+not restricted to arrays of size @${2^n}. For small arrays, a simple naive algorithm is used.
+
+@$${ X_k = \sum_{n=0}^{N-1}{x_n e^{\frac{-2 \pi i k n}{N} }} }
+
+For bigger sizes, if they are a power of 2, then the efficient radix-2 DIT algorithm from
+@racket[array-fft] is used. If the bigger algorithm is not a power of 2, then a Cooley-Turkey
+Fast Fourier transform is selected. This algorithm does not work for sizes that are a prime
+number; for those arrays, an FFT is computed using Rader's algorithm.
+}
+
+@defproc[
+(idft [X (Array A)])
+(Array A)
+]{
+returns the inverse discrete Fourier transform of the array @${X}. The same algorithms are
+selected as for @racket[dft], each one of them in their inverse form.
+}
+
+
+@defproc[
+(cooley-turkey-dft [X (Array A)])
+(Array A)
+]{
+computes the discrete FFT of an array @${X} using the Cooley-Turkey algorithm. This is
+provided for users who want to select the underlying algorithm of @racket[dft].
+}
+
+
+@defproc[
+(rader-dft [X (Array A)])
+(Array A)
+]{
+computes the discrete FFT of an array @${X} using the Rader algorithm. This is provided
+for users who want to select the underlying algorithm of @racket[dft].
 }

--- a/test_approximation.rkt
+++ b/test_approximation.rkt
@@ -7,12 +7,15 @@
          "fundamentals.rkt")
 
 (define-simple-check (check-all-= actual-numbers expected-numbers epsilon)
-                     (for ([actual actual-numbers]
-                           [expected expected-numbers])
-                       (check-= actual expected epsilon)))
+  (for ([actual actual-numbers]
+        [expected expected-numbers])
+    (check-= actual expected epsilon)))
 
 (define-simple-check (check-matrix-= M N epsilon)
-                     (check-all-= (matrix->list M) (matrix->list N) epsilon))
+  (check-all-= (matrix->list M) (matrix->list N) epsilon))
+
+(define-simple-check (check-array-= A B epsilon)
+  (check-all-= (array->list A) (array->list B) epsilon))
 
 (test-case
     "Polyval"
@@ -85,3 +88,8 @@
     (check-= (barycentric xs ys 0.0) 1.0 1e-9)
     ;; Notice how this has to be even nearer to b
     (check-= (barycentric xs ys 5.1) 0.079201 1e-6)))
+
+(test-case
+    "Trigonometric interpolation and FFT"
+  (check-array-= (dft (array #[1])) (array #[1]) 1e-9)
+  (check-array-= (dft (array #[1 1])) (array #[2 0]) 1e-9))

--- a/test_approximation.rkt
+++ b/test_approximation.rkt
@@ -17,6 +17,9 @@
 (define-simple-check (check-array-= A B epsilon)
   (check-all-= (array->list A) (array->list B) epsilon))
 
+(define (array-contiguous-slice arr start end)
+  (array-indexes-ref arr (for/array ([k (in-range start end)]) (vector k))))
+
 (test-case
     "Polyval"
   (define p_0 (col-matrix [1.0]))
@@ -132,4 +135,52 @@
                             1.12813-0.68268i
                             1.32667-1.79495i
                             -0.57596-4.62532i])])
-    (check-array-= actual expected 1e-5)))
+    (check-array-= actual expected 1e-5))
+  ;; Cooley-Turkey algorithm
+  (let* ([n 104]
+         [xs (for/list ([k (in-range (+ n 1))]) (* 2 pi (1 . / . (+ n 1)) k))]
+         [ys (map (lambda (x) (* x (x . - . (* 2 pi)) (exp (* -1 x)))) xs)]
+         [actual (dft (list->array ys))]
+         [expected (array #[-71.8046
+                            -8.3086+44.2580i
+                            9.7192+17.3651i
+                            7.5798+6.9122i
+                            5.1723+3.2650i
+                            ])])
+    (check-array-= (array-contiguous-slice actual 0 5) expected 1e-4))
+  ;; Radix-2 DIT implemented in array-fft
+  (let* ([n 127]
+         [xs (for/list ([k (in-range (+ n 1))]) (* 2 pi (1 . / . (+ n 1)) k))]
+         [ys (map (lambda (x) (* x (x . - . (* 2 pi)) (exp (* -1 x)))) xs)]
+         [actual (dft (list->array ys))]
+         [expected (array #[-87.5457
+                            -10.1411+53.9526i
+                            11.8357+21.1689i
+                            9.2275+8.4263i
+                            6.2928+3.9803i])])
+    (check-array-= (array-contiguous-slice actual 0 5) expected 1e-4))
+  ;; Rader algorithm
+  (let* ([n 100]
+         [xs (for/list ([k (in-range (+ n 1))]) (* 2 pi (1 . / . (+ n 1)) k))]
+         [ys (map (lambda (x) (* x (x . - . (* 2 pi)) (exp (* -1 x)))) xs)]
+         [actual (dft (list->array ys))]
+         [expected (array #[-69.0667
+                            -7.9897+42.5720i
+                            9.3514+16.7036i
+                            7.2935+6.6489i
+                            4.9778+3.1406i])])
+    (check-array-= (array-contiguous-slice actual 0 5) expected 1e-4))
+  (let* ([n 100]
+         [xs (for/list ([k (in-range (+ n 1))]) (* 2 pi (1 . / . (+ n 1)) k))]
+         [ys (map (lambda (x) (* x (x . - . (* 2 pi)) (exp (* -1 x)))) xs)]
+         [actual (idft (list->array ys))]
+         [expected (array #[-0.68382
+                            -0.07910-0.42150i
+                            0.09259-0.16538i
+                            0.07222-0.06583i
+                            0.04929-0.03110i
+                            ])])
+    (check-array-= (array-contiguous-slice actual 0 5) expected 1e-4))
+  )
+
+

--- a/test_approximation.rkt
+++ b/test_approximation.rkt
@@ -133,19 +133,3 @@
                             1.32667-1.79495i
                             -0.57596-4.62532i])])
     (check-array-= actual expected 1e-5)))
-
-(test-case
-    "Factorization of n for FFT"
-  (let-values ([(n1 n2) (fft-factorize 12)])
-    (check-eqv? n1 2)
-    (check-eqv? n2 6)
-    (check-eqv? (* n1 n2) 12))
-  (let-values ([(n1 n2) (fft-factorize 21)])
-    (check-eqv? n1 3)
-    (check-eqv? n2 7)
-    (check-eqv? (* n1 n2) 21))
-  (let-values ([(n1 n2) (fft-factorize 105)])
-    (check-eqv? n1 3)
-    (check-eqv? n2 35)
-    (check-eqv? (* n1 n2) 105))
-  (check-exn exn:fail? (lambda () (fft-factorize 11))))


### PR DESCRIPTION
Add discrete Fourier transformation using FFT Cooley-Turkey and Rader algorithms. The arrays do not need to be of size power of 2.