### PR TITLE
Do not scale inverse DFT when it is built-in

### DIFF
--- a/approximation.rkt
+++ b/approximation.rkt
@@ -97,10 +97,10 @@
                     (inverse-twiddle-factor N l k)))))
   (define (scale result)
     (array-map (λ (x) (* (1 . / . N) x)) result))
-  (scale (cond [(N . < . 100) (naive-idft X)]
-               [(power-of-two? N) (array-inverse-fft X)]
-               [(not  (prime? N)) (cooley-turkey-idft X)]
-               [else              (rader-idft X)])))
+  (cond [(N . < . 100)     (scale (naive-idft X))]
+        [(power-of-two? N) (array-inverse-fft X)]
+        [(not  (prime? N)) (scale (cooley-turkey-idft X))]
+        [else              (scale (rader-idft X))]))
 
 ;; COOLEY-TURKEY-DFT is a fast Fourier transform for arrays of non-prime length
 ;;   cf. http://cnx.org/contents/ulXtQbN7@15/Implementing-FFTs-in-Practice#uid37

--- a/test_approximation.rkt
+++ b/test_approximation.rkt
@@ -159,6 +159,16 @@
                             9.2275+8.4263i
                             6.2928+3.9803i])])
     (check-array-= (array-contiguous-slice actual 0 5) expected 1e-4))
+  (let* ([n 127]
+         [xs (for/list ([k (in-range (+ n 1))]) (* 2 pi (1 . / . (+ n 1)) k))]
+         [ys (map (lambda (x) (* x (x . - . (* 2 pi)) (exp (* -1 x)))) xs)]
+         [actual (idft (list->array ys))]
+         [expected (array #[-0.68395
+                            -0.07923-0.42150i
+                            0.09247-0.16538i
+                            0.07209-0.06583i
+                            0.04916-0.03110i])])
+    (check-array-= (array-contiguous-slice actual 0 5) expected 1e-4))
   ;; Rader algorithm
   (let* ([n 100]
          [xs (for/list ([k (in-range (+ n 1))]) (* 2 pi (1 . / . (+ n 1)) k))]
@@ -180,7 +190,6 @@
                             0.07222-0.06583i
                             0.04929-0.03110i
                             ])])
-    (check-array-= (array-contiguous-slice actual 0 5) expected 1e-4))
-  )
+    (check-array-= (array-contiguous-slice actual 0 5) expected 1e-4)))
 
 


### PR DESCRIPTION
Do not scale the results of the built-in `array-inverse-dft`, because they are already correctly scaled.