### PR TITLE
Add `fftshift` procedure

### DIFF
--- a/approximation.rkt
+++ b/approximation.rkt
@@ -7,7 +7,8 @@
          dft
          idft
          cooley-turkey-dft
-         rader-dft)
+         rader-dft
+         fftshift)
 
 (require math/base
          math/number-theory
@@ -184,3 +185,15 @@
   (define H_tilde (idft (array* (dft h_tilde) (dft w_tilde))))
   (define H (invert-reorder H_tilde))
   (list->array (cons h_0 (array->list H))))
+
+(define (fftshift arr)
+  (define n (array-size arr))
+  (define halfpoint
+    (if (even? n)
+        (/ n 2)
+        (/ (add1 n) 2)))
+  (define left
+    (array-indexes-ref arr (for/array ([k (in-range halfpoint)]) (vector k))))
+  (define right
+    (array-indexes-ref arr (for/array ([k (in-range halfpoint n)]) (vector k))))
+  (array-append* (list right left)))

--- a/scribblings/approximation.scrbl
+++ b/scribblings/approximation.scrbl
@@ -105,3 +105,26 @@ provided for users who want to select the underlying algorithm of @racket[dft].
 computes the discrete FFT of an array @${X} using the Rader algorithm. This is provided
 for users who want to select the underlying algorithm of @racket[dft].
 }
+
+
+@defproc[
+(fftshift [X (Array A)])
+(Array A)
+]{
+rearranges a Fourier transform @${X} by shifting the zero-frequency component to
+the center of the array.
+
+Elements of @${X} are related to coefficients @${c_k} of the trigonometric
+interpolant function @${\widetilde{f}} by the formula:
+
+@$${ c_k = \frac{1}{n + 1} \sum_{j=0}^{n}{f(x_j) e^{-ikjh} } }
+
+for @${k = -M, ..., M}, where
+
+@$${ M = \frac{n - 1}{2} }
+
+After @racket[fftshift], the elements of @${X} are rearranged as
+
+@$${ X_{shifted} = [x_{−(M+μ)}, . . . , x_{−1}, x_0, . . . , x_M ] }
+
+}

--- a/test_approximation.rkt
+++ b/test_approximation.rkt
@@ -192,4 +192,32 @@
                             ])])
     (check-array-= (array-contiguous-slice actual 0 5) expected 1e-4)))
 
+(test-case
+    "fftshift"
+  (let ([x_even (array #[1 2 3 4 5 6])]
+        [expect (array #[4 5 6 1 2 3])])
+    (check-array-= (fftshift x_even) expect 1e-9))
+  (let ([x_odd (array #[1 2 3 4 5 6 7])]
+        [expect (array #[5 6 7 1 2 3 4])])
+    (check-array-= (fftshift x_odd) expect 1e-9)))
 
+
+(test-case
+    "Interpolation in example 3.7"
+  (let* ([n 9]
+         [xs (for/list ([k (in-range (+ n 1))]) (* 2 pi (1 . / . (+ n 1)) k))]
+         [ys (for/array ([x xs]) (* x (x . - . (* 2 pi)) (exp (* -1 x))))]
+         [Y (dft ys)]
+         [C (array-map (λ (x) (x . / . (+ n 1))) (fftshift Y))]
+         [expect (array #[
+                          0.08701
+                          0.09258-0.02140i
+                          0.10985-0.06008i
+                          0.12681-0.16211i
+                          -0.04673-0.42001i
+                          -0.65203
+                          -0.04673+0.42001i
+                          0.12681+0.16211i
+                          0.10985+0.06008i
+                          0.09258+0.02140i])])
+    (check-array-= C expect 1e-5)))


### PR DESCRIPTION
Add `fftshift` procedure which centers results of DFT around zero frequency. This can later be used to implement `interpft`.